### PR TITLE
fix(test-utils): define exports correctly

### DIFF
--- a/.changeset/hungry-shoes-wink.md
+++ b/.changeset/hungry-shoes-wink.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ui/test-utils": patch
+---
+
+Fix: add config and setup files to export on package.json of @fuel-ui/test-utils

--- a/common/test-utils/package.json
+++ b/common/test-utils/package.json
@@ -54,7 +54,8 @@
     "@jest/types": "^28.1.3",
     "@types/jest-axe": "^3.5.4",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "use-resize-observer": "^9.0.2"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/common/test-utils/package.json
+++ b/common/test-utils/package.json
@@ -5,14 +5,22 @@
   "main": "src/index.ts",
   "publishConfig": {
     "access": "public",
-    "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
-    "typings": "./dist/index.d.ts",
+    "main": "./dist/src/index.js",
+    "module": "./dist/src/index.mjs",
+    "types": "./dist/src/index.d.ts",
+    "typings": "./dist/src/index.d.ts",
     "exports": {
       ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
+        "require": "./dist/src/index.js",
+        "default": "./dist/src/index.mjs"
+      },
+      "config": {
+        "require": "./dist/config.js",
+        "default": "./dist/config.mjs"
+      },
+      "setup": {
+        "require": "./dist/setup.js",
+        "default": "./dist/setup.mjs"
       }
     },
     "files": [

--- a/common/test-utils/setup.ts
+++ b/common/test-utils/setup.ts
@@ -21,4 +21,8 @@ if (typeof window.matchMedia !== 'function') {
   });
 }
 
-failOnConsole();
+failOnConsole({
+  shouldFailOnWarn: false,
+});
+
+global.ResizeObserver = require('use-resize-observer/polyfilled');

--- a/common/test-utils/tsup.config.js
+++ b/common/test-utils/tsup.config.js
@@ -4,5 +4,5 @@ import baseConfig from '@fuel-ui/config/tsup';
 export default defineConfig((options) => ({
   ...baseConfig(options),
   external: ['react'],
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'config.ts', 'setup.ts'],
 }));

--- a/design-system/react/src/components/Button/Button.tsx
+++ b/design-system/react/src/components/Button/Button.tsx
@@ -147,7 +147,7 @@ export const Button = createComponent<ButtonProps, ObjProps>(
     const innerRef = useRef<HTMLButtonElement | null>(null);
     const { buttonProps, isPressed } = useButton(
       {
-        ...props,
+        ...omit(["onClick"], props),
         isDisabled,
         ...(isLink && { elementType: "a" }),
         /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,7 @@ importers:
       react-dom: ^18.2.0
       ts-jest: ^28.0.7
       typescript: ^4.7.4
+      use-resize-observer: ^9.0.2
     dependencies:
       '@testing-library/dom': 8.17.1
       '@testing-library/jest-dom': 5.16.5
@@ -146,6 +147,7 @@ importers:
       '@types/jest-axe': 3.5.4
       '@types/testing-library__jest-dom': 5.14.5
       typescript: 4.7.4
+      use-resize-observer: 9.0.2_biqbaboplfbrettd7655fr4n2y
 
   design-system/css:
     specifiers:
@@ -2550,6 +2552,10 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.7
       '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
+
+  /@juggle/resize-observer/3.4.0:
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: true
 
   /@manypkg/find-root/1.1.0:
@@ -17527,6 +17533,22 @@ packages:
       '@types/react': 18.0.17
       react: 18.2.0
     dev: false
+
+  /use-resize-observer/9.0.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-JOzsmF3/IDmtjG7OE5qXOP69LEpBpwhpLSiT1XgSr+uFRX0ftJHQnDaP7Xq+uhbljLYkJt67sqsbnyXBjiY8ig==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: true
 
   /use-sidecar/1.1.2_ug65io7jkbhmo4fihdmbrh3ina:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}


### PR DESCRIPTION
There was a problem when trying to import `@fuel-ui/test-utils/config` file, this wasn't possible:

```jsx
import { config } from '@fuel-ui/test-utils/config` 
```

This pull request fixes this error!