### PR TITLE
feat(react): Make children optional in copyable

### DIFF
--- a/.changeset/polite-ties-share.md
+++ b/.changeset/polite-ties-share.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ui/react": minor
+---
+
+Make children optional in copyable

--- a/design-system/react/src/components/Copyable/Copyable.stories.tsx
+++ b/design-system/react/src/components/Copyable/Copyable.stories.tsx
@@ -13,3 +13,9 @@ export const Usage = () => <Copyable value="Some value">Some value</Copyable>;
 Usage.parameters = {
   layout: 'centered',
 };
+
+export const WithoutChildren = () => <Copyable value="Some value" />;
+
+WithoutChildren.parameters = {
+  layout: 'centered',
+};

--- a/design-system/react/src/components/Copyable/Copyable.tsx
+++ b/design-system/react/src/components/Copyable/Copyable.tsx
@@ -9,7 +9,7 @@ import { IconButton } from '../IconButton';
 
 export type CopyableProps = Omit<FlexProps, 'children'> & {
   value: string;
-  children: ReactNode;
+  children?: ReactNode;
   tooltipMessage?: string;
 };
 


### PR DESCRIPTION
Now the `children` prop is optional in the `Copyable` component

Closes #154 