### PR TITLE
fix: external pr fail to publish coverage table

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  COVERAGE_FILE: ./coverage/report.json
+
 jobs:
   validate-title:
     name: Validate PR Title
@@ -57,12 +60,20 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         id: findPr
 
-      - name: Run tests with coverage
+      - name: Run Jest Tests
+        run: |
+          pnpm test --outputFile="${{ env.COVERAGE_FILE }}"
+
+      - name: Publish coverage
         uses: ArtiomTr/jest-coverage-report-action@v2
+        if: ${{ steps.findPr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           package-manager: pnpm
           annotations: failed-tests
           test-script: pnpm test
-          working-directory: ./design-system/react
           prnumber: ${{ steps.findPr.outputs.number }}
+          skip-test: all
+          working-directory: ./design-system/react
+          coverage-file: ${{ env.COVERAGE_FILE }}
+          base-coverage-file: ${{ env.COVERAGE_FILE }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,6 +61,7 @@ jobs:
         id: findPr
 
       - name: Run Jest Tests
+        working-directory: ./design-system/react
         run: |
           pnpm test --outputFile="${{ env.COVERAGE_FILE }}"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run Jest Tests
         working-directory: ./design-system/react
         run: |
-          pnpm test --outputFile="${{ env.COVERAGE_FILE }}"
+          pnpm run test --outputFile="${{ env.COVERAGE_FILE }}"
 
       - name: Publish coverage
         uses: ArtiomTr/jest-coverage-report-action@v2


### PR DESCRIPTION
Ignore the publish table coverage stage when the contributor is external.