### PR TITLE
fix(react): add typing reference to export FocusScopeProps

### DIFF
--- a/.changeset/neat-beers-accept.md
+++ b/.changeset/neat-beers-accept.md
@@ -1,0 +1,5 @@
+---
+'@fuel-ui/react': patch
+---
+
+Fix: add a typescript typing reference for FocusScope using @react-aria/focus

--- a/design-system/react/package.json
+++ b/design-system/react/package.json
@@ -46,6 +46,7 @@
     "@radix-ui/react-tabs": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.3",
     "@radix-ui/react-visually-hidden": "^1.0.1",
+    "@react-aria/focus": "^3.10.1",
     "@react-aria/overlays": "^3.12.1",
     "@react-aria/utils": "^3.14.2",
     "@stitches/react": "^1.2.8",

--- a/design-system/react/src/components/Focus/Focus.tsx
+++ b/design-system/react/src/components/Focus/Focus.tsx
@@ -1,6 +1,9 @@
 import { FocusArrowNavigator } from './FocusArrowNavigator';
 import { FocusScope } from './FocusScope';
 
+export { FocusArrowNavigatorProps } from './FocusArrowNavigator';
+export { FocusScopeProps } from './FocusScope';
+
 export const Focus = {
   Scope: FocusScope,
   ArrowNavigator: FocusArrowNavigator,

--- a/design-system/react/src/components/Focus/FocusScope.tsx
+++ b/design-system/react/src/components/Focus/FocusScope.tsx
@@ -1,1 +1,2 @@
+/// <reference types="@react-aria/focus" />
 export { FocusScope, FocusScopeProps } from 'react-aria';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,7 @@ importers:
       '@radix-ui/react-tabs': ^1.0.2
       '@radix-ui/react-tooltip': ^1.0.3
       '@radix-ui/react-visually-hidden': ^1.0.1
+      '@react-aria/focus': ^3.10.1
       '@react-aria/overlays': ^3.12.1
       '@react-aria/utils': ^3.14.2
       '@react-types/button': ^3.7.0
@@ -249,6 +250,7 @@ importers:
       '@radix-ui/react-tabs': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-tooltip': 1.0.3_5ndqzdd6t4rivxsukjv3i3ak2q
       '@radix-ui/react-visually-hidden': 1.0.1_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/focus': 3.10.1_react@18.2.0
       '@react-aria/overlays': 3.12.1_biqbaboplfbrettd7655fr4n2y
       '@react-aria/utils': 3.14.2_react@18.2.0
       '@stitches/react': 1.2.8_react@18.2.0


### PR DESCRIPTION
Because we were exporting directly `FocusScopeProps` from `react-aria` and possible it's already exporting directly from 
`@react-aria/focus`, we need to add a `// reference` annotation for Typescript to be able to build.