### PR TITLE
fix: CI not allowing release because of changeset

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   changesets:
-    name: Changeset Checks
+    name: Validate PR Changeset
+    if: ${{ github.head_ref != 'changeset-release/master' && needs.check-packages-changed.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   changesets:
-    name: Validate PR Changeset
+    name: Changeset Checks
     if: ${{ github.head_ref != 'changeset-release/master' && needs.check-packages-changed.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
currently , changeset CI check is failing when it's a release PR (expected)

this PR avoids changeset blocking release PRs