### PR TITLE
fix: add autoFocusKey prop to change autoFocus item to selected item

### DIFF
--- a/design-system/react/src/components/Menu/Menu.test.tsx
+++ b/design-system/react/src/components/Menu/Menu.test.tsx
@@ -28,6 +28,11 @@ describe('Menu', () => {
     expect(screen.getByLabelText('settings')).toHaveFocus();
   });
 
+  it('should be focused when use autoFocus and autoFocusKey', async () => {
+    render(<TestMenu autoFocusKey="trash" />);
+    expect(screen.getByLabelText('trash')).toHaveFocus();
+  });
+
   it('should dispatch onAction using keyboard command', async () => {
     let item: React.Key = '';
     const { user } = render(

--- a/design-system/react/src/components/Menu/Menu.tsx
+++ b/design-system/react/src/components/Menu/Menu.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ThemeUtilsCSS } from '@fuel-ui/css';
 import { cx } from '@fuel-ui/css';
 import { mergeRefs } from '@react-aria/utils';
 import type { FC, Key } from 'react';
@@ -22,9 +23,13 @@ export type MenuProps = HTMLProps['ul'] &
   AriaMenuOptions<unknown> & {
     onAction?: (key: Key) => void;
     autoFocus?: boolean;
+    autoFocusKey?: string;
   };
 
-export type MenuItemProps = ItemProps<BaseMenuItemProps>;
+export type MenuItemProps = ItemProps<BaseMenuItemProps> & {
+  css?: ThemeUtilsCSS;
+  className?: string;
+};
 type ObjProps = {
   Item: FC<MenuItemProps>;
 };
@@ -33,6 +38,7 @@ export const Menu = createComponent<MenuProps, ObjProps>(
   ({
     ref,
     autoFocus,
+    autoFocusKey,
     className,
     onAction,
     selectionMode = 'none',
@@ -50,7 +56,10 @@ export const Menu = createComponent<MenuProps, ObjProps>(
 
     const children = [...state.collection].map((item, idx) => (
       <MenuItem
-        {...(autoFocus && idx === 0 && { autoFocus: true })}
+        {...(autoFocus && {
+          autoFocus: autoFocusKey ? autoFocusKey === item.key : idx === 0,
+        })}
+        css={item.props.css}
         className={item.props.className}
         key={item.key}
         item={item}


### PR DESCRIPTION
### Description
- [x] Added `autoFocusKey` prop to `autoFocus` on selected item instead of always focusing on first item in the `Menu`
- [x] Added `css` and `className` props to `MenuItemProps`