### PR TITLE
fix(react): PasswordStrenght style

### DIFF
--- a/.changeset/light-flies-sit.md
+++ b/.changeset/light-flies-sit.md
@@ -1,0 +1,5 @@
+---
+'@fuel-ui/react': patch
+---
+
+Fix: PasswordStrengh component style was getting an wrong background

--- a/design-system/react/src/components/ContentLoader/ContentLoader.stories.tsx
+++ b/design-system/react/src/components/ContentLoader/ContentLoader.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export const Usage = () => {
   return (
-    <Card css={{ width: 300 }}>
+    <Card css={{ width: 300, padding: '$0' }}>
       <ContentLoader
         speed={2}
         width={300}

--- a/design-system/react/src/components/PasswordStrength/styles.ts
+++ b/design-system/react/src/components/PasswordStrength/styles.ts
@@ -17,11 +17,11 @@ export const styles = {
     layer: 'layer-card',
     px: '$3',
     py: '$3',
-    maxW: '230px',
-    width: '$full',
     flex: 1,
     flexDirection: 'column',
     gap: '$1',
+    background: 'transparent',
+    borderColor: 'transparent',
 
     h5: {
       lineHeight: 1,

--- a/turbo.json
+++ b/turbo.json
@@ -2,10 +2,11 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "cache": false
     },
     "build:storybook": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "cache": false
     },
     "test": {
       "dependsOn": []


### PR DESCRIPTION
I just missed some fixes in the last commit inside the `<PasswordStrenght>` component that was getting a wrong background from the `layer` definition