### PR TITLE
fix: amountInput for 18 units

### DIFF
--- a/design-system/react/src/components/InputAmount/InputAmount.stories.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.stories.tsx
@@ -31,8 +31,10 @@ const BALANCE = bn.parseUnits('1.570000044');
 
 const Template: StoryFn<typeof InputAmount> = (args) => {
   const [amount, setAmount] = useState<BN | null>(bn());
-  const AMOUNT_VALUE_1 = 1_000_000_011;
-  const AMOUNT_VALUE_2 = 1_000_000_000;
+  const { units } = args || {};
+
+  const valueOne = bn.parseUnits('1', units).add(11);
+  const valueTwo = bn.parseUnits('1', units);
 
   // Log onChange amount
   useEffect(() => {
@@ -46,13 +48,13 @@ const Template: StoryFn<typeof InputAmount> = (args) => {
       <InputAmount {...args} onChange={setAmount} value={amount} />
       <Stack gap="$3">
         <Text fontSize="lg" css={{ marginTop: '$2' }}>
-          Amount: {amount?.format({ precision: 9 })}
+          Amount: {amount?.format({ precision: units, units })}
         </Text>
-        <Button onPress={() => setAmount(bn(AMOUNT_VALUE_1))}>
-          Set ({bn(AMOUNT_VALUE_1).format({ precision: 9 })})
+        <Button onPress={() => setAmount(valueOne)}>
+          Set ({valueOne.format({ precision: units, units })})
         </Button>
-        <Button onPress={() => setAmount(bn(AMOUNT_VALUE_2))}>
-          Set ({bn(AMOUNT_VALUE_2).format({ precision: 3 })})
+        <Button onPress={() => setAmount(valueTwo)}>
+          Set ({valueTwo.format({ precision: units, units })})
         </Button>
         <Button onPress={() => setAmount(null)}>Clear</Button>
       </Stack>
@@ -63,6 +65,12 @@ const Template: StoryFn<typeof InputAmount> = (args) => {
 export const Usage = Template.bind({});
 Usage.args = {
   balance: BALANCE,
+};
+
+export const EthUnits = Template.bind({});
+EthUnits.args = {
+  balance: bn.parseUnits('1.570000044', 18),
+  units: 18,
 };
 
 export const NoBalance = Template.bind({});

--- a/design-system/react/src/components/InputAmount/InputAmount.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.tsx
@@ -1,5 +1,5 @@
 import type { BN } from '@fuel-ts/math';
-import { bn } from '@fuel-ts/math';
+import { bn, format } from '@fuel-ts/math';
 import { cssObj } from '@fuel-ui/css';
 import type { PressEvent } from '@react-types/shared';
 import { useEffect, useState } from 'react';
@@ -17,7 +17,7 @@ import { Text } from '../Text';
 import { Tooltip } from '../Tooltip';
 
 import { InputAmountLoader } from './InputAmountLoader';
-import { DECIMAL_UNITS, createAmount, formatAmount } from './utils';
+import { DECIMAL_UNITS, createAmount } from './utils';
 
 export type InputAmountProps = Omit<InputProps, 'size'> & {
   name?: string;
@@ -54,23 +54,27 @@ export const InputAmount: InputAmountComponent = ({
   onClickAsset,
   ...props
 }) => {
-  const formatOpts = { units };
+  const formatOpts = { units, precision: units };
   const [assetAmount, setAssetAmount] = useState<string>(
-    !value || value.eq(0) ? '' : formatAmount(value, formatOpts)
+    !value || value.eq(0) ? '' : value.format(formatOpts)
   );
 
   const balance = initialBalance ?? bn(initialBalance);
-  const formattedBalance = formatAmount(balance, {
+  const formattedBalance = balance.format({
+    ...formatOpts,
     precision: balance.eq(0) ? 1 : balancePrecision,
   });
 
   useEffect(() => {
-    handleAmountChange(value ? formatAmount(value, formatOpts) : '');
+    handleAmountChange(value ? value.format(formatOpts) : '');
   }, [value?.toString()]);
 
   const handleAmountChange = (text: string) => {
-    const { text: newText, amount } = createAmount(text);
-    const { amount: currentAmount } = createAmount(assetAmount);
+    const { text: newText, amount } = createAmount(text, formatOpts.units);
+    const { amount: currentAmount } = createAmount(
+      assetAmount,
+      formatOpts.units
+    );
     if (!currentAmount.eq(amount)) {
       onChange?.(amount);
       setAssetAmount(newText);
@@ -79,7 +83,7 @@ export const InputAmount: InputAmountComponent = ({
 
   const handleSetBalance = () => {
     if (balance) {
-      handleAmountChange(formatAmount(balance, formatOpts));
+      handleAmountChange(balance.format(formatOpts));
     }
   };
 
@@ -160,7 +164,7 @@ export const InputAmount: InputAmountComponent = ({
           <Box as="span" css={styles.balance}>
             Balance:{' '}
           </Box>
-          <Tooltip content={formatAmount(balance, formatOpts)} sideOffset={-5}>
+          <Tooltip content={format(balance, formatOpts)} sideOffset={-5}>
             <Box as="span" css={styles.balance}>
               {formattedBalance}
             </Box>

--- a/design-system/react/src/components/InputAmount/utils.tsx
+++ b/design-system/react/src/components/InputAmount/utils.tsx
@@ -1,4 +1,3 @@
-import type { BNInput, FormatConfig } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
 
 export const DECIMAL_UNITS = 9;
@@ -24,8 +23,4 @@ export function createAmount(text: string, units: number = DECIMAL_UNITS) {
     text: textAmountFixed,
     amount: bn.parseUnits(text.replaceAll(',', ''), units),
   };
-}
-
-export function formatAmount(amount: BNInput, opts: FormatConfig = {}) {
-  return bn(amount).format(opts);
 }


### PR DESCRIPTION
Closes [FRO-121](https://linear.app/fuel-network/issue/FRO-121/amount-input-not-working-with-18-units)

There were bugs when using AmountInput with 18 units:
- was not working to type after 9 decimal units (0.000000001)
- was not working to set balance with more than 9 decimal units
- value was not showing correctly for more than 9 decimal units
- balance showing incorrectly

This PR:
- completely fixes the usage of AmountInput
- split some tests and also create new ones to cover bugged scenarios
  - applied tests to both 9 and 18 units