### PR TITLE
feat(InputAmount): show AvatarGenerated when asset has no image

### DIFF
--- a/.changeset/hip-hornets-sniff.md
+++ b/.changeset/hip-hornets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@fuel-ui/react': patch
+---
+
+InputAmount: when asset has no image, show AvatarGenerated using address as hash for it

--- a/design-system/react/src/components/Avatar/Avatar.stories.tsx
+++ b/design-system/react/src/components/Avatar/Avatar.stories.tsx
@@ -56,10 +56,17 @@ export const Generated = (args: AvatarProps) => (
   </Box>
 );
 
-export const GeneratedCustomSize = (args: AvatarProps) => (
+export const GeneratedSizes = (args: AvatarProps) => (
   <Box css={{ display: 'flex', alignItems: 'center', gap: '$3' }}>
-    {EXAMPLE_HASHES.map((hash) => {
-      return <Avatar.Generated size={20} key={hash} {...args} hash={hash} />;
+    {AVATAR_SIZES.map((size, i) => {
+      return (
+        <Avatar.Generated
+          size={size}
+          key={EXAMPLE_HASHES[i]}
+          {...args}
+          hash={EXAMPLE_HASHES[i]}
+        />
+      );
     })}
   </Box>
 );

--- a/design-system/react/src/components/InputAmount/InputAmount.stories.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.stories.tsx
@@ -88,8 +88,8 @@ NoAction.args = {
   hiddenMaxButton: true,
 };
 
-export const WithAsset = Template.bind({});
-WithAsset.args = {
+export const Asset = Template.bind({});
+Asset.args = {
   label: 'Amount',
   balance: BALANCE,
   asset: {
@@ -99,8 +99,8 @@ WithAsset.args = {
   onClickAsset: undefined,
 };
 
-export const WithAssetTooltip = Template.bind({});
-WithAssetTooltip.args = {
+export const AssetTooltip = Template.bind({});
+AssetTooltip.args = {
   label: 'Amount',
   balance: BALANCE,
   asset: {
@@ -111,8 +111,8 @@ WithAssetTooltip.args = {
   onClickAsset: undefined,
 };
 
-export const WithAssetOnClick = Template.bind({});
-WithAssetOnClick.args = {
+export const AssetOnClick = Template.bind({});
+AssetOnClick.args = {
   label: 'Amount',
   balance: BALANCE,
   asset: {
@@ -122,6 +122,17 @@ WithAssetOnClick.args = {
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   onClickAsset: () => {},
+};
+
+export const AssetNoImage = Template.bind({});
+AssetNoImage.args = {
+  label: 'Amount',
+  balance: BALANCE,
+  asset: {
+    name: 'ETH',
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  },
+  onClickAsset: undefined,
 };
 
 export const Loader = () => (

--- a/design-system/react/src/components/InputAmount/InputAmount.test.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.test.tsx
@@ -184,7 +184,7 @@ describe('InputAmount', () => {
   it('should show asset generated image when asset address is passed with no imageUrl', async () => {
     render(<InputAmount asset={MOCK_ASSET} balance={MOCK_BALANCE.amount} />);
     expect(
-      screen.getByAltText(`${MOCK_ASSET.name} generated image`),
+      screen.getByLabelText(`${MOCK_ASSET.name} generated image`),
     ).toBeInTheDocument();
   });
 });

--- a/design-system/react/src/components/InputAmount/InputAmount.test.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.test.tsx
@@ -9,9 +9,13 @@ import { DECIMAL_UNITS } from './utils';
 
 const AMOUNT_TEXT = `14.563`;
 const FIELD_NAME = 'Input Amount';
-export const MOCK_ASSET = {
+const MOCK_BALANCE = {
   assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
   amount: bn.parseUnits(AMOUNT_TEXT),
+};
+const MOCK_ASSET = {
+  name: 'USD',
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 };
 
 function Content({ onChange, ...props }: Partial<InputAmountProps>) {
@@ -25,7 +29,7 @@ function Content({ onChange, ...props }: Partial<InputAmountProps>) {
   return (
     <InputAmount
       name={FIELD_NAME}
-      balance={MOCK_ASSET.amount}
+      balance={MOCK_BALANCE.amount}
       onChange={handleChange}
       value={bn(val)}
       {...props}
@@ -143,7 +147,7 @@ describe('InputAmount', () => {
   );
 
   it('should display balance in input when click on max button', async () => {
-    const { user } = render(<InputAmount balance={MOCK_ASSET.amount} />);
+    const { user } = render(<InputAmount balance={MOCK_BALANCE.amount} />);
     const maxBtn = screen.getByLabelText('Max');
     expect(maxBtn).toBeInTheDocument();
     await user.click(maxBtn);
@@ -154,12 +158,14 @@ describe('InputAmount', () => {
   });
 
   it('should hidden Balance when prop hiddenBalance is true', async () => {
-    render(<InputAmount hiddenBalance={true} balance={MOCK_ASSET.amount} />);
+    render(<InputAmount hiddenBalance={true} balance={MOCK_BALANCE.amount} />);
     expect(() => screen.getByLabelText(`Balance: ${AMOUNT_TEXT}`)).toThrow();
   });
 
   it('should hidden Max Button when prop hiddenMaxButton is true', async () => {
-    render(<InputAmount hiddenMaxButton={true} balance={MOCK_ASSET.amount} />);
+    render(
+      <InputAmount hiddenMaxButton={true} balance={MOCK_BALANCE.amount} />,
+    );
     expect(() => screen.getByLabelText('Max')).toThrow();
   });
 
@@ -173,5 +179,12 @@ describe('InputAmount', () => {
     render(<InputAmount balance={bn(0)} />);
     expect(screen.getByLabelText('Balance: 0.0')).toBeInTheDocument();
     expect(screen.getByLabelText('Max')).toBeInTheDocument();
+  });
+
+  it('should show asset generated image when asset address is passed with no imageUrl', async () => {
+    render(<InputAmount asset={MOCK_ASSET} />);
+    expect(
+      screen.getByAltText(`${MOCK_ASSET.name} generated image`),
+    ).toBeInTheDocument();
   });
 });

--- a/design-system/react/src/components/InputAmount/InputAmount.test.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.test.tsx
@@ -182,7 +182,7 @@ describe('InputAmount', () => {
   });
 
   it('should show asset generated image when asset address is passed with no imageUrl', async () => {
-    render(<InputAmount asset={MOCK_ASSET} />);
+    render(<InputAmount asset={MOCK_ASSET} balance={MOCK_BALANCE.amount} />);
     expect(
       screen.getByAltText(`${MOCK_ASSET.name} generated image`),
     ).toBeInTheDocument();

--- a/design-system/react/src/components/InputAmount/InputAmount.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.tsx
@@ -5,6 +5,7 @@ import type { PressEvent } from '@react-types/shared';
 import { useEffect, useState } from 'react';
 import type { FC } from 'react';
 
+import { Avatar } from '../Avatar';
 import { Box } from '../Box';
 import { Flex } from '../Box/Flex';
 import { Button } from '../Button';
@@ -25,7 +26,7 @@ export type InputAmountProps = Omit<InputProps, 'size'> & {
   balance?: BN;
   units?: number;
   balancePrecision?: number;
-  asset?: { name?: string; imageUrl?: string };
+  asset?: { name?: string; imageUrl?: string; address?: string };
   assetTooltip?: string;
   hiddenMaxButton?: boolean;
   hiddenBalance?: boolean;
@@ -89,6 +90,26 @@ export const InputAmount: InputAmountComponent = ({
     }
   };
 
+  const getAssetImage = () => {
+    if (asset?.imageUrl) {
+      return (
+        <Image
+          css={styles.image}
+          src={asset.imageUrl}
+          alt={`${asset.name} image`}
+        />
+      );
+    }
+
+    return (
+      <Avatar.Generated
+        hash={asset?.address || asset?.name || ''}
+        css={styles.image}
+        alt={`${asset?.name} generated image`}
+      />
+    );
+  };
+
   return (
     <Input size="lg" css={styles.input} {...props}>
       <Text fontSize="sm" color="textSubtext">
@@ -135,13 +156,8 @@ export const InputAmount: InputAmountComponent = ({
                     onPress={onClickAsset}
                     isDisabled={!onClickAsset}
                     css={styles.assetButton}
-                    leftIcon={
-                      <Image
-                        alt={asset.name}
-                        src={asset.imageUrl}
-                        css={styles.image}
-                      />
-                    }
+                    iconSize={20}
+                    leftIcon={getAssetImage()}
                     data-dropdown={!!onClickAsset}
                     rightIcon={onClickAsset && <Icon icon="ChevronDown" />}
                   >

--- a/design-system/react/src/components/InputAmount/InputAmount.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.tsx
@@ -105,7 +105,7 @@ export const InputAmount: InputAmountComponent = ({
       <Avatar.Generated
         hash={asset?.address || asset?.name || ''}
         css={styles.image}
-        alt={`${asset?.name} generated image`}
+        aria-label={`${asset?.name} generated image`}
       />
     );
   };


### PR DESCRIPTION
Closes FRO-431


InputAmount
- Show AvatarGenerated when has no imageUrl in the asset informed

AvatarGenerated
- Fix storybook for AvatarGenerated with sizes 