### PR TITLE
chore: change variant of max button

### DIFF
--- a/.changeset/polite-apricots-shake.md
+++ b/.changeset/polite-apricots-shake.md
@@ -1,0 +1,5 @@
+---
+'@fuel-ui/react': patch
+---
+
+chore: use outlined variant for InputAmount select asset button

--- a/design-system/react/src/components/InputAmount/InputAmount.tsx
+++ b/design-system/react/src/components/InputAmount/InputAmount.tsx
@@ -151,7 +151,7 @@ export const InputAmount: InputAmountComponent = ({
                   <Button
                     size="sm"
                     aria-label="Coin Selector"
-                    variant="ghost"
+                    variant="outlined"
                     intent="base"
                     onPress={onClickAsset}
                     isDisabled={!onClickAsset}


### PR DESCRIPTION
 use outlined variant for the "select asset" button in the InputAmount component